### PR TITLE
Fail cache downloads when required, retry on memory alloc fail

### DIFF
--- a/common/network.go
+++ b/common/network.go
@@ -273,6 +273,7 @@ type Artifacts []Artifact
 type Cache struct {
 	Key       string        `json:"key"`
 	Untracked bool          `json:"untracked"`
+	Required  bool          `json:"required"`
 	Policy    CachePolicy   `json:"policy"`
 	Paths     ArtifactPaths `json:"paths"`
 	When      CacheWhen     `json:"when"`

--- a/shells/bash.go
+++ b/shells/bash.go
@@ -71,6 +71,11 @@ func (b *BashWriter) CheckForErrors() {
 	b.Line("_runner_exit_code=$?; if [[ $_runner_exit_code -ne 0 ]]; then exit $_runner_exit_code; fi")
 }
 
+func (b *BashWriter) Exit(code int) {
+	b.Line(fmt.Sprintf("exit %d", code))
+	b.Line("")
+}
+
 func (b *BashWriter) Indent() {
 	b.indent++
 }

--- a/shells/cmd.go
+++ b/shells/cmd.go
@@ -77,6 +77,11 @@ func (b *CmdWriter) CheckForErrors() {
 	b.checkErrorLevel()
 }
 
+func (b *CmdWriter) Exit(code int) {
+	b.Line(fmt.Sprintf("exit /b %d", code))
+	b.Line("")
+}
+
 func (b *CmdWriter) Indent() {
 	b.indent++
 }

--- a/shells/mock_ShellWriter.go
+++ b/shells/mock_ShellWriter.go
@@ -85,6 +85,11 @@ func (_m *MockShellWriter) Errorf(fmt string, arguments ...interface{}) {
 	_m.Called(_ca...)
 }
 
+// Exit provides a mock function with given fields: code
+func (_m *MockShellWriter) Exit(code int) {
+	_m.Called(code)
+}
+
 // Finish provides a mock function with given fields: trace
 func (_m *MockShellWriter) Finish(trace bool) string {
 	ret := _m.Called(trace)

--- a/shells/powershell.go
+++ b/shells/powershell.go
@@ -133,6 +133,11 @@ func (p *PsWriter) CheckForErrors() {
 	p.checkErrorLevel()
 }
 
+func (p *PsWriter) Exit(code int) {
+	p.Line(fmt.Sprintf("Exit %d", code))
+	p.Line("")
+}
+
 func (p *PsWriter) Indent() {
 	p.indent++
 }

--- a/shells/shell_writer.go
+++ b/shells/shell_writer.go
@@ -33,6 +33,7 @@ type ShellWriter interface {
 	Warningf(fmt string, arguments ...interface{})
 	Errorf(fmt string, arguments ...interface{})
 	EmptyLine()
+	Exit(code int)
 
 	Finish(trace bool) string
 }


### PR DESCRIPTION
## Issue

Cache downloads can fail when containers have memory pressure.  This happens somewhat regularly with our jobs, particularly when the cache has a lot of files in the ZIP, such as a node_modules cache.

The problem is that these do NOT fail the job on the cache unzip failure but the cache is effectively corrupt: files will be missing or truncated.

My theory is that this is due to GC pressure.  The extract code unzips all of the files, iterating the archive in a loop.  Inspecting the Golang `flate` library, there does not appear to be pooling between the decompressors, eg. they each allocate their own memory.  It looks like they try to use fairly small buffers, but its not clear how much they might store at a given time.  In any case, with an archive that may have 100K files, this loop will create these things quickly and GC may get behind.

So this fix:

1. Detects memory errors
2. Retries memory allocation errors 3 times
3. Waits 1s and triggers a GC on memory error

Separately, it introduces a `required` field on `cache` so that failures to unzip the cache will fail the job immediately.  This seems like the ideal behavior (a broken cache is going to be a broken build), but to make this non-breaking this field is introduced as a `boolean`.

## Symptom

```
Downloading cache.zip from https://s3.dualstack.us-west-2.amazonaws.com/ci-gitlab.foo.com/project/3304/ui-cache 
WARNING: ui/node_modules/date-fns/locale/ta/_lib/match/index.js: write ui/node_modules/date-fns/locale/ta/_lib/match/index.js: cannot allocate memory (suppressing repeats) 
WARNING: logn-ui/node_modules/date-fns/locale/ta/index.d.ts: read ../../../../../../cache/...-monorepo/cache.zip: cannot allocate memory (suppressing repeats) 
/scripts-dafas-2051793280/restore_cache: line 203:   113 Killed                  '/usr/bin/gitlab-runner-helper' "cache-extractor" 
```

These are intermittent and will succeed on retrying the job in many cases.



Added tests, etc.

Might be worth splitting into 2 PRs, one for the extractor, one for the command / cache changes.