### PR TITLE
restore lost argument "NoProfile" in encoded command

### DIFF
--- a/shells/powershell.go
+++ b/shells/powershell.go
@@ -125,7 +125,7 @@ func pwshStdinCmdArgs(shell string) []string {
 	var sb strings.Builder
 
 	sb.WriteString("$OutputEncoding = [console]::InputEncoding = [console]::OutputEncoding = New-Object System.Text.UTF8Encoding\r\n")
-	sb.WriteString(shell + " -Command -\r\n")
+	sb.WriteString(shell + " -NoProfile -Command -\r\n")
 	encoded, _ := encoder.String(sb.String())
 
 	return []string{


### PR DESCRIPTION
# Issue
The NoProfile argument is lost in the encoded pwsh command.
If there is a system profile on the computer "C:\Program Files\PowerShell\7\profile.ps1", it is read and executed